### PR TITLE
Download the wordnet from nltk

### DIFF
--- a/Topic_Modeling/functions.py
+++ b/Topic_Modeling/functions.py
@@ -10,6 +10,7 @@ import nltk
 from nltk.tokenize import RegexpTokenizer
 from nltk.stem.wordnet import WordNetLemmatizer
 nltk.download('punkt')
+nltk.download('wordnet')
 
 
 #General Data processing Modules


### PR DESCRIPTION
The machine learning model is dependent on `wordnet` database from nltk for lexical analysis. Add the code to download it on the machine the fastapi server is triggered. This might be redundant and could be solved with simpler solutions. In that case, Please reject the PR and delete the branch. Thanks. 